### PR TITLE
refact: 명소 상세조회 응답값 수정

### DIFF
--- a/src/main/java/com/CUK/geulDa/domain/place/dto/PlaceDetailResponse.java
+++ b/src/main/java/com/CUK/geulDa/domain/place/dto/PlaceDetailResponse.java
@@ -12,7 +12,7 @@ public record PlaceDetailResponse(
         return new PlaceDetailResponse(placeId, true, imageUrl, placeName, description, address);
     }
 
-    public static PlaceDetailResponse incomplete(Long placeId) {
-        return new PlaceDetailResponse(placeId, false, null, null, null, null);
+    public static PlaceDetailResponse incomplete(Long placeId,String placeName, String description, String address) {
+        return new PlaceDetailResponse(placeId, false, null, placeName, description, address);
     }
 }

--- a/src/main/java/com/CUK/geulDa/domain/place/service/PlaceService.java
+++ b/src/main/java/com/CUK/geulDa/domain/place/service/PlaceService.java
@@ -47,7 +47,11 @@ public class PlaceService {
                     place.getAddress()
             );
         } else {
-            return PlaceDetailResponse.incomplete(place.getId());
+            return PlaceDetailResponse.incomplete(
+				place.getId(),
+				place.getName(),
+				place.getDescription(),
+				place.getAddress());
         }
     }
 


### PR DESCRIPTION
## 관련 이슈
Closes #29 

## 작업 내용
- 스탬프가 없는 명소도 장소 정보(placeName, description, address)도 받도록 변경

## 변경 사항
-  PlaceDetailResponse.java
  - incomplete() 팩토리 메서드가 이제 장소 정보(placeName, description, address)도 받도록 변경
  - 이전: 완료되지 않은 장소는 모든 필드가 null
  - 변경: 완료되지 않은 장소도 기본 정보는 반환, imageUrl만 null

  PlaceService.java:50-54
  - incomplete() 호출 시 장소 정보를 함께 전달

## 테스트
- [ ] 로컬 테스트 완료
- [ ] 단위 테스트 통과
- [ ] API 테스트 완료

## 스크린샷
(필요시 첨부)

## 리뷰 요청 사항
